### PR TITLE
Remove cargo-fmt

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,9 +16,6 @@
 [submodule "src/cargo-edit"]
 	path = src/cargo-edit
 	url = https://github.com/killercup/cargo-edit
-[submodule "src/cargo-fmt"]
-	path = src/cargo-fmt
-	url = https://github.com/pwoolcoc/cargo-fmt
 [submodule "src/cargo-script"]
 	path = src/cargo-script
 	url = https://github.com/DanielKeep/cargo-script

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,10 +55,6 @@ name = "cargo-rm"
 path = "src/cargo-edit/src/bin/rm/main.rs"
 
 [[bin]]
-name = "cargo-fmt"
-path = "src/cargo-fmt/src/main.rs"
-
-[[bin]]
 name = "cargo-script"
 path = "src/cargo-script/src/main.rs"
 
@@ -105,8 +101,6 @@ pad = "~0.1"
 curl = "~0.2.11"
 quick-error = "0.1.3"
 cargo-edit = "~0.1"
-### cargo-fmt
-walker = "^1.0.0"
 ### cargo-script
 env_logger = "0.3.1"
 hoedown = "3.0.3"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Because one of the subcommands requires `cmake` to build, you must have `cmake` 
 
 ### Primary Method: `cargo install`
 
-To install from [crates.io](https://crates.io) simply run 
+To install from [crates.io](https://crates.io) simply run
 
 ```
 $ cargo install cargo-extras
@@ -64,7 +64,7 @@ Follow these instructions to compile `cargo-extras`, then skip down to Installat
  3. Build the project `$ cargo build --release` (**NOTE:** There is a large performance difference when compiling without optimizations, so I recommend always using `--release` to enable to them)
  4. Once complete, all the binaries will be located at `target/release/`
 
-#### Installation 
+#### Installation
 
 All you need to do is place the binary subcommands somewhere in your `$PATH`. Then run `cargo <command>` anywhere in your project directory. Example:
 
@@ -112,7 +112,6 @@ Otherwise, ensure you have the binaries in the directory which you operating in 
  * [cargo-count v0.1.3](https://github.com/kbknapp/cargo-count) - lists source code counts and details about cargo projects, including unsafe statistics
  * [cargo-do v0.3.1 (b120fce315)](https://github.com/pwoolcoc/cargo-do) - run multiple `cargo` commands in a row
  * [cargo-edit v0.1.1 (3ae8e70bf1)](https://github.com/killercup/cargo-edit) - allows you to add and remove dependencies from the command line. Installs `cargo-add`, `cargo-rm`, and `cargo-list`.
- * [cargo-fmt v0.1.0 (e24dc7bdfb)](https://github.com/pwoolcoc/cargo-fmt) - allows running [rustfmt](https://github.com/rust-lang-nursery/rustfmt) from `cargo`
  * [cargo-graph v0.2.0](https://github.com/kbknapp/cargo-graph) - builds dependency graphs using GraphViz `dot` and is an updated fork of [cargo-dot](https://github.com/maxsnew/cargo-dot) with additional features
  * [cargo-open v0.3.0 (c070fb01b5)](https://github.com/carols10cents/cargo-open) - quickly open a crate in your `$EDITOR`
  * [cargo-outdated v0.1.3](https://github.com/kbknapp/cargo-outdated) - displays when newer versions of Rust dependencies are available, or out of date


### PR DESCRIPTION
cargo-fmt is now bundled with rustfmt, so there's no need for this cargo subcommand in cargo-extras.
[Fix #19]
